### PR TITLE
Simplify script for checking tarball + fix validation error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,6 @@ script:
 
  # check that the generated source-distribution can be built & installed
  - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
-   cd dist && cabal install --force-reinstalls "$SRC_TGZ"
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
 
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,13 +97,7 @@ script:
  - cabal sdist
 
  # check that the generated source-distribution can be built & installed
- - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
-   cd dist/;
-   if [ -f "$SRC_TGZ" ]; then
-      cabal install --force-reinstalls "$SRC_TGZ";
-   else
-      echo "expected '$SRC_TGZ' not found";
-      exit 1;
-   fi
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   cd dist && cabal install --force-reinstalls "$SRC_TGZ"
 
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # NB: don't set `language: haskell` here
+language: c
 
 # See also https://github.com/hvr/multi-ghc-travis for more information
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ script:
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
 
-# The following scriptlet checks that the resulting source distribution can be built & installed
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
  - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
    cd dist && cabal install --force-reinstalls "$SRC_TGZ"
 

--- a/README.md
+++ b/README.md
@@ -89,14 +89,8 @@ script:
  - cabal sdist   # tests that a source-distribution can be generated
 
 # The following scriptlet checks that the resulting source distribution can be built & installed
- - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
-   cd dist/;
-   if [ -f "$SRC_TGZ" ]; then
-      cabal install --force-reinstalls "$SRC_TGZ";
-   else
-      echo "expected '$SRC_TGZ' not found";
-      exit 1;
-   fi
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   cd dist && cabal install --force-reinstalls "$SRC_TGZ"
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ script:
 # If there are no other `.tar.gz` files in `dist`, this can be even simpler:
 # `cabal install --force-reinstalls dist/*-*.tar.gz`
  - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
-   cd dist && cabal install --force-reinstalls "$SRC_TGZ"
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
 
 ```
 


### PR DESCRIPTION
  - Make the script for checking the source tarball simpler by removing the `if` test (unless there's a reason I didn't anticipate?).
  - Also add `language: c` to please the [validator](http://yaml.travis-ci.org).
  - Can just use `cabal install dist/*-*.tar.gz` if there is no source of confusion.