### PR TITLE
Compare old and new install plans in correct order

### DIFF
--- a/make_travis_yml.hs
+++ b/make_travis_yml.hs
@@ -130,7 +130,7 @@ genTravisFromCabalFile fn xpkgs = do
         , " - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt"
         , ""
         , "# check whether current requested install-plan matches cached package-db snapshot"
-        , " - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;"
+        , " - if diff -u $HOME/.cabsnap/installplan.txt installplan.txt;"
         , "   then"
         , "     echo \"cabal build-cache HIT\";"
         , "     rm -rfv .ghc;"


### PR DESCRIPTION
Argument order for diff -u was swapped, and it appeared that packages were downgraded

E.g. `base-orphans` from 0.5.2 to 0.5.1:

```diff
--- installplan.txt	2016-02-28 00:55:57.273548425 +0000
+++ /home/travis/.cabsnap/installplan.txt	2016-02-13 02:05:20.000000000 +0000
@@ -1,7 +1,7 @@
 In order, the following would be installed:
 Cabal-1.22.4.0 (latest: 1.22.7.0) (via: uuagc-cabal-1.0.6.0) (new version)
 HUnit-1.3.1.1 (new package)
-base-orphans-0.5.2 (via: semigroupoids-5.0.1 profunctors-5.2 distributive-0.5.0.2) (new package)
+base-orphans-0.5.1 (via: semigroupoids-5.0.1 profunctors-5.2 distributive-0.5.0.2) (new package)
```