### PR TITLE
Removing dist/ in a new-build repo requires removing .ghc.environment.*, too.

### DIFF
--- a/make_travis_yml_2.hs
+++ b/make_travis_yml_2.hs
@@ -300,7 +300,7 @@ genTravisFromCabalFile (argv,opts) fn xpkgs = do
         , "# any command which exits with a non-zero exit code causes the build to fail."
         , "script:"
         , " - if [ -f configure.ac ]; then autoreconf -i; fi"
-        , " - rm -rf dist/"
+        , " - rm -rf .ghc.environment.* dist/"
         , " - cabal sdist # test that a source-distribution can be generated"
         , " - cd dist/"
         , " - SRCTAR=(${PKGNAME}-*.tar.gz)"


### PR DESCRIPTION
If `dist/` is deleted but .ghc.environment.* is not, then the repository is in a state that's going to confuse Cabal.

Fixes https://github.com/hvr/multi-ghc-travis/issues/81.