### PR TITLE
Add support for cabal.project files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,55 +40,51 @@ matrix:
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.1], sources: [hvr-ghc]}}
 
 before_install:
- - HC=${CC}
- - HCPKG=${HC/ghc/ghc-pkg}
- - unset CC
- - PATH=/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$PATH
- - PKGNAME='make-travis-yml'
+  - HC=${CC}
+  - HCPKG=${HC/ghc/ghc-pkg}
+  - unset CC
+  - PATH=/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$PATH
 
 install:
- - cabal --version
- - echo "$(${HC} --version) [$(${HC} --print-project-git-commit-id 2> /dev/null || echo '?')]"
- - BENCH=${BENCH---enable-benchmarks}
- - TEST=${TEST---enable-tests}
- - HADDOCK=${HADDOCK-true}
- - INSTALLED=${INSTALLED-true}
- - travis_retry cabal update -v
- - sed -i.bak 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - rm -fv cabal.project.local
- - "echo 'packages: .' > cabal.project"
- - rm -f cabal.project.freeze
- - cabal new-build -w ${HC} ${TEST} ${BENCH} --dep -j2 all
- - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --dep -j2 all
+  - cabal --version
+  - echo "$(${HC} --version) [$(${HC} --print-project-git-commit-id 2> /dev/null || echo '?')]"
+  - BENCH=${BENCH---enable-benchmarks}
+  - TEST=${TEST---enable-tests}
+  - HADDOCK=${HADDOCK-true}
+  - INSTALLED=${INSTALLED-true}
+  - travis_retry cabal update -v
+  - sed -i.bak 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+  - rm -fv cabal.project.local
+  - "echo 'packages: .' > cabal.project"
+  - if [ -f "./configure.ac" ]; then
+      (cd "."; autoreconf -i);
+    fi
+  - rm -f cabal.project.freeze
+  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
+  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
+  - rm -rf "."/.ghc.environment.* "."/dist
+  - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
- - if [ -f configure.ac ]; then autoreconf -i; fi
- - rm -rf .ghc.environment.* dist/
- - cabal sdist # test that a source-distribution can be generated
- - cd dist/
- - SRCTAR=(${PKGNAME}-*.tar.gz)
- - SRC_BASENAME="${SRCTAR/%.tar.gz}"
- - tar -xvf "./$SRC_BASENAME.tar.gz"
- - cd "$SRC_BASENAME/"
-## from here on, CWD is inside the extracted source-tarball
- - rm -fv cabal.project.local
- - "echo 'packages: .' > cabal.project"
- # this builds all libraries and executables (without tests/benchmarks)
- - rm -f cabal.project.freeze
- - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all
- # this builds all libraries and executables (including tests/benchmarks)
- # - rm -rf ./dist-newstyle
+  # test that source-distributions can be generated
+  - (cd "."; cabal sdist)
+  - mv "."/dist/make-travis-yml-*.tar.gz ${DISTDIR}/
+  - cd ${DISTDIR}
+  - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
+  - "printf 'packages: make-travis-yml-*/*.cabal\n' > cabal.project"
+  # this builds all libraries and executables (without tests/benchmarks)
+  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all
 
- # Build with installed constraints for packages in global-db
- - if $INSTALLED; then
-     echo cabal new-build -w ${HC} --disable-tests --disable-benchmarks $(${HCPKG} list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh;
-   else echo "Not building with installed constraints"; fi
+  # Build with installed constraints for packages in global-db
+  - if $INSTALLED; then
+      echo cabal new-build -w ${HC} --disable-tests --disable-benchmarks $(${HCPKG} list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh;
+    else echo "Not building with installed constraints"; fi
 
- # build & run tests, build benchmarks
- - cabal new-build -w ${HC} ${TEST} ${BENCH} all
- - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} all; fi
+  # build & run tests, build benchmarks
+  - cabal new-build -w ${HC} ${TEST} ${BENCH} all
+  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} all; fi
 
 # REGENDATA ["-o",".travis.yml","make-travis-yml.cabal"]
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ script:
 
  # build & run tests, build benchmarks
  - cabal new-build -w ${HC} ${TEST} ${BENCH} all
+ - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} all; fi
 
 # REGENDATA ["-o",".travis.yml","make-travis-yml.cabal"]
 # EOF

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,2 @@
+Cabal files and directory structure from Servant, copyright of the Servant
+contributors, licensed under BSD3.

--- a/MakeTravisYml.hs
+++ b/MakeTravisYml.hs
@@ -1,0 +1,1 @@
+make_travis_yml_2.hs

--- a/Tests.hs
+++ b/Tests.hs
@@ -1,0 +1,62 @@
+module Main (main) where
+
+import MakeTravisYml (travisFromCabalFile, Options (..), defOptions, options)
+
+import Control.Monad.Trans.Writer
+import Data.Algorithm.Diff (Diff (..), getGroupedDiff)
+import System.Console.GetOpt (getOpt, ArgOrder(Permute))
+import System.Exit (exitFailure)
+import System.FilePath (replaceExtension, (</>))
+import System.IO (hPutStrLn, stderr)
+import Test.Tasty (TestName, TestTree, defaultMain, testGroup)
+import Test.Tasty.Golden.Advanced (goldenTest)
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+
+main :: IO ()
+main = defaultMain $ testGroup "fixtures"
+    [ fixtureGoldenTest "make-travis-yml.cabal"
+        ["-o",".travis.yml","make-travis-yml.cabal"]
+    ]
+
+-- | 
+-- @
+-- travisFromCabalFile ::
+--    ... => ([String],Options) -> FilePath -> [String] -> Writer [String] m ()
+-- @
+fixtureGoldenTest :: FilePath ->  [String] -> TestTree
+fixtureGoldenTest fp argv = cabalGoldenTest fp output $ do
+    (opts, _fp, xpkgs) <- parseOpts argv
+    fmap (BS8.pack . unlines) $ execWriterT $
+        -- always pass empty argv
+        -- TODO: make test take argv, parse them.
+        travisFromCabalFile (argv, opts) fp xpkgs
+  where
+    input = "fixtures" </> fp
+    output = replaceExtension input "travis.yml"
+
+
+parseOpts :: [String] -> IO (Options, FilePath, [String])
+parseOpts argv = case getOpt Permute options argv of
+    (opts,cabfn:xpkgs,[]) -> return (foldl (flip id) defOptions opts,cabfn,xpkgs)
+    (_,_,[]) -> dieCli ["expected .cabal fle as first non-option argument\n"]
+    (_,_,errs) -> dieCli errs
+  where
+    dieCli errs = hPutStrLn stderr (unlines errs) >> exitFailure
+
+cabalGoldenTest :: TestName -> FilePath -> IO BS.ByteString -> TestTree
+cabalGoldenTest name ref act = goldenTest name (BS.readFile ref) act cmp upd
+  where
+    upd = BS.writeFile ref
+    cmp x y | x == y = return Nothing
+    cmp x y = return $ Just $ unlines $
+        concatMap f (getGroupedDiff (BS8.lines x) (BS8.lines y))
+      where
+        f (First xs)  = map (cons3 '-' . BS8.unpack) xs
+        f (Second ys) = map (cons3 '+' . BS8.unpack) ys
+        -- we print unchanged lines too. It shouldn't be a problem while we have
+        -- reasonably small examples
+        f (Both xs _) = map (cons3 ' ' . BS8.unpack) xs
+        -- we add three characters, so the changed lines are easier to spot
+        cons3 c cs = c : c : c : ' ' : cs

--- a/Tests.hs
+++ b/Tests.hs
@@ -1,6 +1,6 @@
 module Main (main) where
 
-import MakeTravisYml (travisFromCabalFile, Options (..), defOptions, options)
+import MakeTravisYml (travisFromConfigFile, Options (..), defOptions, options)
 
 import Control.Monad.Trans.Writer
 import Data.Algorithm.Diff (Diff (..), getGroupedDiff)
@@ -31,7 +31,7 @@ fixtureGoldenTest fp argv = cabalGoldenTest fp output $ do
     fmap (BS8.pack . unlines) $ execWriterT $
         -- always pass empty argv
         -- TODO: make test take argv, parse them.
-        travisFromCabalFile (argv, opts) fp xpkgs
+        travisFromConfigFile (argv, opts) fp xpkgs
   where
     input = "fixtures" </> fp
     output = replaceExtension input "travis.yml"

--- a/fixtures/cabal.project.empty-line
+++ b/fixtures/cabal.project.empty-line
@@ -1,0 +1,5 @@
+packages:
+  servant/
+  servant-client/
+  servant-docs/
+  servant-server/

--- a/fixtures/cabal.project.fail-versions
+++ b/fixtures/cabal.project.fail-versions
@@ -1,0 +1,7 @@
+packages: servant/
+  servant-client/
+  servant-client-core/
+  servant-docs/
+  servant-foreign/
+  servant-server/
+  doc/tutorial/

--- a/fixtures/doc/tutorial/tutorial.cabal
+++ b/fixtures/doc/tutorial/tutorial.cabal
@@ -1,0 +1,65 @@
+name:                tutorial
+version:             0.10
+synopsis:            The servant tutorial
+homepage:            http://haskell-servant.readthedocs.org/
+license:             BSD3
+license-file:        LICENSE
+author:              Servant Contributors
+maintainer:          haskell-servant-maintainers@googlegroups.com
+build-type:          Simple
+cabal-version:       >=1.10
+tested-with:         GHC >= 7.10
+
+library
+  exposed-modules:     ApiType
+                     , Authentication
+                     , Client
+                     , Docs
+                     , Javascript
+                     , Server
+  build-depends:       base == 4.*
+                     , base-compat
+                     , text
+                     , aeson
+                     , aeson-compat
+                     , blaze-html
+                     , directory
+                     , blaze-markup
+                     , containers
+                     , servant == 0.11.*
+                     , servant-server == 0.11.*
+                     , servant-client == 0.11.*
+                     , servant-docs == 0.11.*
+                     , servant-js >= 0.9 && <0.10
+                     , warp
+                     , http-api-data
+                     , http-media
+                     , lucid
+                     , time
+                     , string-conversions
+                     , bytestring
+                     , attoparsec
+                     , mtl
+                     , random
+                     , js-jquery
+                     , wai
+                     , http-types
+                     , transformers
+                     , markdown-unlit >= 0.4
+                     , http-client
+  default-language:    Haskell2010
+  ghc-options:         -Wall -pgmL markdown-unlit
+  build-tool-depends: markdown-unlit:markdown-unlit
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  ghc-options: -Wall
+  default-language: Haskell2010
+  hs-source-dirs: test
+  main-is: Spec.hs
+  other-modules: JavascriptSpec
+  build-depends: base == 4.*
+               , tutorial
+               , hspec
+               , hspec-wai
+               , string-conversions

--- a/fixtures/make-travis-yml.cabal
+++ b/fixtures/make-travis-yml.cabal
@@ -1,0 +1,1 @@
+../make-travis-yml.cabal

--- a/fixtures/make-travis-yml.travis.yml
+++ b/fixtures/make-travis-yml.travis.yml
@@ -1,0 +1,1 @@
+../.travis.yml

--- a/fixtures/servant-client-core/servant-client-core.cabal
+++ b/fixtures/servant-client-core/servant-client-core.cabal
@@ -1,0 +1,75 @@
+name:                servant-client-core
+version:             0.11
+synopsis:            Core functionality and class for client function generation for servant APIs
+description:
+  This library provides backend-agnostic generation of client functions. For
+  more information, see the README.
+license:             BSD3
+license-file:        LICENSE
+author:              Servant Contributors
+maintainer:          haskell-servant-maintainers@googlegroups.com
+homepage:            http://haskell-servant.readthedocs.org/
+bug-reports:         http://github.com/haskell-servant/servant/issues
+cabal-version:       >=1.10
+copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2017 Servant Contributors
+category:            Web
+build-type:          Simple
+tested-with:         GHC >= 7.10
+extra-source-files:
+  include/*.h
+  CHANGELOG.md
+  README.md
+source-repository head
+  type:              git
+  location:          http://github.com/haskell-servant/servant.git
+
+library
+  exposed-modules:
+      Servant.Client.Core
+      Servant.Client.Core.Reexport
+      Servant.Client.Core.Internal.Auth
+      Servant.Client.Core.Internal.BaseUrl
+      Servant.Client.Core.Internal.BasicAuth
+      Servant.Client.Core.Internal.Generic
+      Servant.Client.Core.Internal.HasClient
+      Servant.Client.Core.Internal.Request
+      Servant.Client.Core.Internal.RunClient
+  build-depends:
+      base                  >= 4.7      && < 4.11
+    , base-compat           >= 0.9.1    && < 0.10
+    , base64-bytestring     >= 1.0.0.1  && < 1.1
+    , bytestring            >= 0.10     && < 0.11
+    , containers            >= 0.5      && < 0.6
+    , exceptions            >= 0.8      && < 0.9
+    , generics-sop          >= 0.1.0.0  && < 0.4
+    , http-api-data         >= 0.3.6    && < 0.4
+    , http-media            >= 0.6.2    && < 0.8
+    , http-types            >= 0.8.6    && < 0.10
+    , mtl                   >= 2.1      && < 2.3
+    , network-uri           >= 2.6      && < 2.7
+    , safe                  >= 0.3.9    && < 0.4
+    , servant               == 0.11.*
+    , text                  >= 1.2      && < 1.3
+  if !impl(ghc >= 8.0)
+    build-depends:
+        semigroups          >=0.16.2.2 && <0.19
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+  include-dirs:        include
+
+test-suite spec
+  type:                exitcode-stdio-1.0
+  ghc-options:         -Wall
+  default-language:    Haskell2010
+  hs-source-dirs:      test
+  main-is:             Spec.hs
+  build-depends:
+      base
+    , base-compat
+    , deepseq
+    , servant-client-core
+    , hspec == 2.*
+    , QuickCheck >= 2.7 && < 2.11
+  other-modules:
+      Servant.Client.Core.Internal.BaseUrlSpec

--- a/fixtures/servant-client/servant-client.cabal
+++ b/fixtures/servant-client/servant-client.cabal
@@ -1,0 +1,94 @@
+name:                servant-client
+version:             0.11
+synopsis: automatical derivation of querying functions for servant webservices
+description:
+  This library lets you derive automatically Haskell functions that
+  let you query each endpoint of a <http://hackage.haskell.org/package/servant servant> webservice.
+  .
+  See <http://haskell-servant.readthedocs.org/en/stable/tutorial/Client.html the client section of the tutorial>.
+  .
+  <https://github.com/haskell-servant/servant/blob/master/servant-client/CHANGELOG.md CHANGELOG>
+license:             BSD3
+license-file:        LICENSE
+author:              Servant Contributors
+maintainer:          haskell-servant-maintainers@googlegroups.com
+copyright:           2014-2016 Zalora South East Asia Pte Ltd, 2016-2017 Servant Contributors
+category:            Servant, Web
+build-type:          Simple
+cabal-version:       >=1.10
+tested-with:         GHC >= 7.8
+homepage:            http://haskell-servant.readthedocs.org/
+Bug-reports:         http://github.com/haskell-servant/servant/issues
+extra-source-files:
+  include/*.h
+  CHANGELOG.md
+  README.md
+source-repository head
+  type: git
+  location: http://github.com/haskell-servant/servant.git
+
+library
+  exposed-modules:
+    Servant.Client
+    Servant.Client.Internal.HttpClient
+  build-depends:
+      base                  >= 4.7      && < 4.11
+    , base-compat           >= 0.9.1    && < 0.10
+    , bytestring            >= 0.10     && < 0.11
+    , aeson                 >= 0.7      && < 1.3
+    , attoparsec            >= 0.12     && < 0.14
+    , containers            >= 0.5      && < 0.6
+    , http-client           >= 0.4.30   && < 0.6
+    , http-client-tls       >= 0.2.2    && < 0.4
+    , http-media            >= 0.6.2    && < 0.8
+    , http-types            >= 0.8.6    && < 0.10
+    , exceptions            >= 0.8      && < 0.9
+    , monad-control         >= 1.0.0.4  && < 1.1
+    , mtl                   >= 2.1      && < 2.3
+    , semigroupoids         >= 4.3      && < 5.3
+    , servant-client-core   == 0.11.*
+    , text                  >= 1.2      && < 1.3
+    , transformers          >= 0.3      && < 0.6
+    , transformers-base     >= 0.4.4    && < 0.5
+    , transformers-compat   >= 0.4      && < 0.6
+  hs-source-dirs: src
+  default-language: Haskell2010
+  ghc-options: -Wall
+  if impl(ghc >= 8.0)
+    ghc-options: -Wno-redundant-constraints
+  include-dirs: include
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  ghc-options: -Wall
+  default-language: Haskell2010
+  hs-source-dirs: test
+  main-is: Spec.hs
+  other-modules:
+      Servant.ClientSpec
+  build-depends:
+      base == 4.*
+    , aeson
+    , base-compat
+    , bytestring
+    , containers
+    , deepseq
+    , hspec == 2.*
+    , http-api-data
+    , http-client
+    , http-media
+    , http-types
+    , HUnit
+    , mtl
+    , network >= 2.6
+    , QuickCheck >= 2.7
+    , servant
+    , servant-client
+    , servant-client-core
+    , servant-server == 0.11.*
+    , text
+    , transformers
+    , transformers-compat
+    , wai
+    , warp
+    , generics-sop

--- a/fixtures/servant-docs/servant-docs.cabal
+++ b/fixtures/servant-docs/servant-docs.cabal
@@ -1,0 +1,88 @@
+name:                servant-docs
+version:             0.11
+synopsis:            generate API docs for your servant webservice
+description:
+  Library for generating API docs from a servant API definition.
+  .
+  Runnable example <https://github.com/haskell-servant/servant/blob/master/servant-docs/example/greet.hs here>.
+  .
+  <https://github.com/haskell-servant/servant/blob/master/servant-docs/CHANGELOG.md CHANGELOG>
+license:             BSD3
+license-file:        LICENSE
+author:              Servant Contributors
+maintainer:          haskell-servant-maintainers@googlegroups.com
+copyright:           2014-2016 Zalora South East Asia Pte Ltd, Servant Contributors
+category:            Servant, Web
+build-type:          Simple
+cabal-version:       >=1.10
+tested-with:         GHC >= 7.8
+homepage:            http://haskell-servant.readthedocs.org/
+Bug-reports:         http://github.com/haskell-servant/servant/issues
+extra-source-files:
+  include/*.h
+  CHANGELOG.md
+  README.md
+source-repository head
+  type: git
+  location: http://github.com/haskell-servant/servant.git
+
+library
+  exposed-modules:
+      Servant.Docs
+    , Servant.Docs.Internal
+    , Servant.Docs.Internal.Pretty
+  build-depends:
+      base >=4.7 && <5
+    , base-compat >= 0.9.1 && <0.10
+    , aeson
+    , aeson-pretty
+    , bytestring
+    , case-insensitive
+    , hashable
+    , http-media >= 0.6
+    , http-types >= 0.7
+    , lens
+    , servant == 0.11.*
+    , string-conversions
+    , text
+    , unordered-containers
+    , control-monad-omega == 0.3.*
+  if !impl(ghc >= 8.0)
+    build-depends:
+      semigroups          >=0.17 && <0.19
+  hs-source-dirs: src
+  default-language: Haskell2010
+  ghc-options: -Wall
+  if impl(ghc >= 8.0)
+    ghc-options: -Wno-redundant-constraints
+  include-dirs: include
+
+executable greet-docs
+  main-is: greet.hs
+  hs-source-dirs: example
+  ghc-options: -Wall
+  build-depends:
+      base
+    , aeson
+    , lens
+    , servant
+    , servant-docs
+    , string-conversions
+    , text
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules: Servant.DocsSpec
+  hs-source-dirs: test
+  ghc-options: -Wall
+  build-depends:
+      base
+    , aeson
+    , hspec
+    , lens
+    , servant
+    , servant-docs
+    , string-conversions
+  default-language: Haskell2010

--- a/fixtures/servant-foreign/servant-foreign.cabal
+++ b/fixtures/servant-foreign/servant-foreign.cabal
@@ -1,0 +1,85 @@
+name:                servant-foreign
+version:             0.10.1
+synopsis:            Helpers for generating clients for servant APIs in any programming language
+description:
+  Helper types and functions for generating client functions for servant APIs in any programming language
+  .
+  This package provides types and functions that collect all the data needed to generate client functions in the programming language of your choice. This effectively means you only have to write the code that "pretty-prints" this data as some code in your target language.
+  .
+  See the servant-js package for an example
+  .
+  <https://github.com/haskell-servant/servant/blob/master/servant-foreign/CHANGELOG.md CHANGELOG>
+license:             BSD3
+license-file:        LICENSE
+author:              Servant Contributors
+maintainer:          haskell-servant-maintainers@googlegroups.com
+copyright:           2015-2016 Servant Contributors
+category:            Servant, Web
+build-type:          Simple
+cabal-version:       >=1.10
+tested-with:         GHC >= 7.10
+extra-source-files:
+  include/*.h
+  CHANGELOG.md
+  README.md
+bug-reports:         http://github.com/haskell-servant/servant/issues
+source-repository head
+  type: git
+  location: http://github.com/haskell-servant/servant.git
+
+library
+  exposed-modules:     Servant.Foreign
+                     , Servant.Foreign.Internal
+                     , Servant.Foreign.Inflections
+  build-depends:       base       == 4.*
+                     , lens       == 4.*
+                     , servant    == 0.11.*
+                     , text       >= 1.2  && < 1.3
+                     , http-types
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+  if impl(ghc >= 8.0)
+    ghc-options: -Wno-redundant-constraints
+  include-dirs: include
+  default-extensions:  CPP
+                     , ConstraintKinds
+                     , DataKinds
+                     , FlexibleContexts
+                     , FlexibleInstances
+                     , GeneralizedNewtypeDeriving
+                     , MultiParamTypeClasses
+                     , ScopedTypeVariables
+                     , StandaloneDeriving
+                     , TemplateHaskell
+                     , TypeFamilies
+                     , TypeOperators
+                     , UndecidableInstances
+                     , OverloadedStrings
+                     , PolyKinds
+
+
+test-suite spec
+  type:              exitcode-stdio-1.0
+  hs-source-dirs:    test
+  ghc-options:       -Wall
+  include-dirs:      include
+  main-is:           Spec.hs
+  other-modules:     Servant.ForeignSpec
+  build-depends:     base
+                   , hspec >= 2.1.8
+                   , servant
+                   , servant-foreign
+  default-language:  Haskell2010
+  default-extensions:  ConstraintKinds
+                     , DataKinds
+                     , FlexibleContexts
+                     , FlexibleInstances
+                     , GeneralizedNewtypeDeriving
+                     , MultiParamTypeClasses
+                     , ScopedTypeVariables
+                     , TypeFamilies
+                     , TypeOperators
+                     , UndecidableInstances
+                     , OverloadedStrings
+                     , PolyKinds

--- a/fixtures/servant-server/servant-server.cabal
+++ b/fixtures/servant-server/servant-server.cabal
@@ -1,0 +1,166 @@
+name:                servant-server
+version:             0.11
+synopsis:            A family of combinators for defining webservices APIs and serving them
+description:
+  A family of combinators for defining webservices APIs and serving them
+  .
+  You can learn about the basics in the <http://haskell-servant.readthedocs.org/en/stable/tutorial/index.html tutorial>.
+  .
+  <https://github.com/haskell-servant/servant/blob/master/servant-server/example/greet.hs Here>
+  is a runnable example, with comments, that defines a dummy API and implements
+  a webserver that serves this API, using this package.
+  .
+  <https://github.com/haskell-servant/servant/blob/master/servant-server/CHANGELOG.md CHANGELOG>
+homepage:            http://haskell-servant.readthedocs.org/
+Bug-reports:         http://github.com/haskell-servant/servant/issues
+license:             BSD3
+license-file:        LICENSE
+author:              Servant Contributors
+maintainer:          haskell-servant-maintainers@googlegroups.com
+copyright:           2014-2016 Zalora South East Asia Pte Ltd, Servant Contributors
+category:            Servant, Web
+build-type:          Custom
+cabal-version:       >=1.10
+tested-with:         GHC >= 7.8
+extra-source-files:
+  include/*.h
+  CHANGELOG.md
+  README.md
+bug-reports:         http://github.com/haskell-servant/servant/issues
+source-repository head
+  type: git
+  location: http://github.com/haskell-servant/servant.git
+
+custom-setup
+  setup-depends:
+    base >= 4 && <5,
+    Cabal,
+    cabal-doctest >= 1.0.1 && <1.1
+
+library
+  exposed-modules:
+    Servant
+    Servant.Server
+    Servant.Server.Experimental.Auth
+    Servant.Server.Internal
+    Servant.Server.Internal.BasicAuth
+    Servant.Server.Internal.Context
+    Servant.Server.Internal.Handler
+    Servant.Server.Internal.Router
+    Servant.Server.Internal.RoutingApplication
+    Servant.Server.Internal.ServantErr
+    Servant.Utils.StaticFiles
+  build-depends:
+        base               >= 4.7  && < 4.11
+      , base-compat        >= 0.9  && < 0.10
+      , aeson              >= 0.7  && < 1.3
+      , attoparsec         >= 0.12 && < 0.14
+      , base64-bytestring  >= 1.0  && < 1.1
+      , bytestring         >= 0.10 && < 0.11
+      , containers         >= 0.5  && < 0.6
+      , exceptions         >= 0.8  && < 0.9
+      , http-api-data      >= 0.3  && < 0.4
+      , http-types         >= 0.8  && < 0.10
+      , network-uri        >= 2.6  && < 2.7
+      , monad-control      >= 1.0.0.4 && < 1.1
+      , mtl                >= 2    && < 2.3
+      , network            >= 2.6  && < 2.7
+      , safe               >= 0.3  && < 0.4
+      , servant            == 0.11.*
+      , split              >= 0.2  && < 0.3
+      , string-conversions >= 0.3  && < 0.5
+      , system-filepath    >= 0.4  && < 0.5
+      , filepath           >= 1    && < 1.5
+      , resourcet          >= 1.1.6 && <1.2
+      , tagged             >= 0.7.3 && <0.9
+      , text               >= 1.2  && < 1.3
+      , transformers       >= 0.3  && < 0.6
+      , transformers-base  >= 0.4.4 && < 0.5
+      , transformers-compat>= 0.4  && < 0.6
+      , wai                >= 3.0  && < 3.3
+      , wai-app-static     >= 3.1  && < 3.2
+      , warp               >= 3.0  && < 3.3
+      , word8              >= 0.1  && < 0.2
+
+  hs-source-dirs: src
+  default-language: Haskell2010
+  ghc-options: -Wall
+  if impl(ghc >= 8.0)
+    ghc-options: -Wno-redundant-constraints
+  include-dirs: include
+
+executable greet
+  main-is: greet.hs
+  hs-source-dirs: example
+  ghc-options: -Wall
+  default-language: Haskell2010
+  build-depends:
+      base
+    , servant
+    , servant-server
+    , aeson
+    , warp
+    , wai
+    , text
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  ghc-options: -Wall
+  default-language: Haskell2010
+  hs-source-dirs: test
+  main-is: Spec.hs
+  other-modules:
+      Servant.ArbitraryMonadServerSpec
+      Servant.Server.ErrorSpec
+      Servant.Server.Internal.ContextSpec
+      Servant.Server.Internal.RoutingApplicationSpec
+      Servant.Server.RouterSpec
+      Servant.Server.StreamingSpec
+      Servant.Server.UsingContextSpec
+      Servant.Server.UsingContextSpec.TestCombinators
+      Servant.ServerSpec
+      Servant.Utils.StaticFilesSpec
+  build-depends:
+      base == 4.*
+    , base-compat
+    , aeson
+    , base64-bytestring
+    , bytestring
+    , directory
+    , exceptions
+    , hspec == 2.*
+    , hspec-wai >= 0.8 && <0.9
+    , http-types
+    , mtl
+    , network >= 2.6
+    , parsec
+    , QuickCheck
+    , resourcet
+    , safe
+    , servant
+    , servant-server
+    , should-not-typecheck == 2.1.*
+    , string-conversions
+    , temporary
+    , text
+    , transformers
+    , transformers-compat
+    , wai
+    , wai-extra
+    , warp
+
+test-suite doctests
+ build-depends: base
+              , servant
+              , doctest
+              , filemanip
+              , directory
+              , filepath
+ type: exitcode-stdio-1.0
+ main-is: test/doctests.hs
+ buildable: True
+ default-language: Haskell2010
+ ghc-options: -Wall -threaded
+ if impl(ghc >= 8.2)
+   x-doctest-options: -fdiagnostics-color=never
+ include-dirs: include

--- a/fixtures/servant/servant.cabal
+++ b/fixtures/servant/servant.cabal
@@ -1,0 +1,157 @@
+name:                servant
+version:             0.11
+synopsis:            A family of combinators for defining webservices APIs
+description:
+  A family of combinators for defining webservices APIs and serving them
+  .
+  You can learn about the basics in the <http://haskell-servant.readthedocs.org/en/stable/tutorial/index.html tutorial>.
+  .
+  <https://github.com/haskell-servant/servant/blob/master/servant/CHANGELOG.md CHANGELOG>
+homepage:            http://haskell-servant.readthedocs.org/
+Bug-reports:         http://github.com/haskell-servant/servant/issues
+license:             BSD3
+license-file:        LICENSE
+author:              Servant Contributors
+maintainer:          haskell-servant-maintainers@googlegroups.com
+copyright:           2014-2016 Zalora South East Asia Pte Ltd, Servant Contributors
+category:            Servant, Web
+build-type:          Custom
+cabal-version:       >=1.10
+tested-with:         GHC >= 7.8
+extra-source-files:
+  include/*.h
+  CHANGELOG.md
+source-repository head
+  type: git
+  location: http://github.com/haskell-servant/servant.git
+
+custom-setup
+  setup-depends:
+    base >= 4 && <5,
+    Cabal,
+    cabal-doctest >= 1.0.2 && <1.1
+
+library
+  exposed-modules:
+    Servant.API
+    Servant.API.Alternative
+    Servant.API.BasicAuth
+    Servant.API.Capture
+    Servant.API.ContentTypes
+    Servant.API.Description
+    Servant.API.Empty
+    Servant.API.Experimental.Auth
+    Servant.API.Header
+    Servant.API.HttpVersion
+    Servant.API.Internal.Test.ComprehensiveAPI
+    Servant.API.IsSecure
+    Servant.API.QueryParam
+    Servant.API.Raw
+    Servant.API.RemoteHost
+    Servant.API.ReqBody
+    Servant.API.ResponseHeaders
+    Servant.API.Sub
+    Servant.API.TypeLevel
+    Servant.API.Vault
+    Servant.API.Verbs
+    Servant.API.WithNamedContext
+    Servant.Utils.Links
+    Servant.Utils.Enter
+  build-depends:
+      base                  >= 4.7  && < 4.11
+    , base-compat           >= 0.9  && < 0.10
+    , aeson                 >= 0.7  && < 1.3
+    , attoparsec            >= 0.12 && < 0.14
+    , bytestring            >= 0.10 && < 0.11
+    , case-insensitive      >= 1.2  && < 1.3
+    , http-api-data         >= 0.3  && < 0.4
+    , http-media            >= 0.4  && < 0.8
+    , http-types            >= 0.8  && < 0.10
+    , natural-transformation >= 0.4 && < 0.5
+    , mtl                   >= 2.0  && < 2.3
+    , mmorph                >= 1    && < 1.2
+    , tagged                >= 0.7.3 && < 0.9
+    , text                  >= 1    && < 1.3
+    , string-conversions    >= 0.3  && < 0.5
+    , network-uri           >= 2.6  && < 2.7
+    , vault                 >= 0.3  && < 0.4
+
+  if !impl(ghc >= 8.0)
+    build-depends:
+      semigroups            >= 0.16 && < 0.19
+
+  hs-source-dirs: src
+  default-language: Haskell2010
+  other-extensions: CPP
+                  , ConstraintKinds
+                  , DataKinds
+                  , DeriveDataTypeable
+                  , FlexibleInstances
+                  , FunctionalDependencies
+                  , GADTs
+                  , KindSignatures
+                  , MultiParamTypeClasses
+                  , OverlappingInstances
+                  , OverloadedStrings
+                  , PolyKinds
+                  , QuasiQuotes
+                  , RecordWildCards
+                  , ScopedTypeVariables
+                  , TemplateHaskell
+                  , TypeFamilies
+                  , TypeOperators
+                  , TypeSynonymInstances
+                  , UndecidableInstances
+  ghc-options: -Wall
+  if impl(ghc >= 8.0)
+    ghc-options: -Wno-redundant-constraints
+  include-dirs: include
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  ghc-options: -Wall
+  default-language: Haskell2010
+  hs-source-dirs: test
+  main-is: Spec.hs
+  other-modules:
+      Servant.API.ContentTypesSpec
+      Servant.API.ResponseHeadersSpec
+      Servant.Utils.LinksSpec
+      Servant.Utils.EnterSpec
+  build-depends:
+      base == 4.*
+    , base-compat
+    , aeson
+    , aeson-compat >=0.3.3 && <0.4
+    , attoparsec
+    , bytestring
+    , hspec == 2.*
+    , QuickCheck
+    , quickcheck-instances
+    , servant
+    , string-conversions
+    , text
+    , url
+
+  if !impl(ghc >= 8.0)
+    build-depends:
+      semigroups            >= 0.16 && < 0.19
+
+test-suite doctests
+ build-depends: base
+              , servant
+              , doctest
+              , filemanip
+              , directory
+              , filepath
+              , hspec
+ type: exitcode-stdio-1.0
+ main-is: test/doctests.hs
+ buildable: True
+ default-language: Haskell2010
+ ghc-options: -Wall -threaded
+ if impl(ghc >= 8.2)
+   x-doctest-options: -fdiagnostics-color=never
+ include-dirs: include
+ x-doctest-source-dirs: test
+ x-doctest-modules: Servant.Utils.LinksSpec

--- a/make-travis-yml.cabal
+++ b/make-travis-yml.cabal
@@ -26,6 +26,9 @@ executable make-travis-yml
   other-extensions:    CPP, ViewPatterns
   build-depends:       base  >=4.7  && <4.11
                      , Cabal >=1.10 && <2.1
+                     , containers >=0.4 && <0.6
+                     , directory >=1.1 && <1.4
+                     , filepath >=1.2 && <1.5
                      , transformers >= 0.3 && <0.6
                      , deepseq >=1.3 && <1.5
   default-language:    Haskell2010
@@ -44,6 +47,8 @@ test-suite golden
                      , Cabal >=1.10 && <2.1
                      , transformers >= 0.3 && <0.6
                      , deepseq >=1.3 && <1.5
+                     , containers >=0.4 && <0.6
+                     , directory >=1.1 && <1.4
                      , filepath
                      , bytestring
                      , tasty >= 0.11.3 && <0.12

--- a/make-travis-yml.cabal
+++ b/make-travis-yml.cabal
@@ -16,9 +16,13 @@ tested-with:
   GHC == 7.10.3,
   GHC == 8.0.2,
   GHC == 8.2.1
+extra-source-files:
+  fixtures/*.cabal
+  fixtures/*.travis.yml
 
 executable make-travis-yml
-  main-is:             make_travis_yml_2.hs
+  main-is:             MakeTravisYml.hs
+  ghc-options:         -main-is MakeTravisYml
   other-extensions:    CPP, ViewPatterns
   build-depends:       base  >=4.7  && <4.11
                      , Cabal >=1.10 && <2.1
@@ -31,3 +35,18 @@ executable make-travis-yml
 --   build-depends:       base  >=4.7  && <4.11
 --                      , Cabal >=1.10 && <1.25
 --   default-language:    Haskell2010
+
+test-suite golden
+  type:              exitcode-stdio-1.0
+  main-is:           Tests.hs
+  other-modules:     MakeTravisYml
+  build-depends:       base  >=4.7  && <4.11
+                     , Cabal >=1.10 && <2.1
+                     , transformers >= 0.3 && <0.6
+                     , deepseq >=1.3 && <1.5
+                     , filepath
+                     , bytestring
+                     , tasty >= 0.11.3 && <0.12
+                     , tasty-golden >=2.3.1.1 && <2.4
+                     , Diff >=0.3.4 && <0.4
+  default-language:    Haskell2010

--- a/make_travis_yml_2.hs
+++ b/make_travis_yml_2.hs
@@ -20,7 +20,7 @@
 --
 -- NB: This code deliberately avoids relying on non-standard packages and
 --     is expected to compile/work with at least GHC 7.0 through GHC 8.0
-module Main where
+module MakeTravisYml where
 
 import Control.Applicative ((<|>))
 import Control.DeepSeq (force)
@@ -182,7 +182,12 @@ runFileWriter mfp m = do
         Just fp -> writeFile fp contents
 
 genTravisFromCabalFile :: ([String],Options) -> FilePath -> [String] -> IO ()
-genTravisFromCabalFile (argv,opts) fn xpkgs = runFileWriter (optOutput opts) $ do
+genTravisFromCabalFile argvOpts@(_, opts) fn xpkgs = runFileWriter (optOutput opts) $
+    travisFromCabalFile argvOpts fn xpkgs
+
+travisFromCabalFile :: MonadIO m => ([String],Options) -> FilePath -> [String] -> WriterT [String] m ()
+travisFromCabalFile (argv,opts) fn xpkgs = do
+
     gpd <- liftIO $ readGenericPackageDescription maxBound fn
 
     let compilers = testedWith $ packageDescription $ gpd

--- a/make_travis_yml_2.hs
+++ b/make_travis_yml_2.hs
@@ -298,7 +298,8 @@ travisFromConfigFile args@(_, opts) path xpkgs =
         collectConfig aggregate (pkg, config, testWith) =
             aggregate <> (errors, config, [pkg])
           where
-            diff = S.difference testWith allVersions
+            symDiff a b = S.union a b `S.difference` S.intersection a b
+            diff = symDiff testWith allVersions
             missingVersions = map dispGhcVersion $ S.toList diff
             errors | S.null diff = []
                    | otherwise = pure $ mconcat

--- a/make_travis_yml_2.hs
+++ b/make_travis_yml_2.hs
@@ -345,7 +345,7 @@ configFromCabalFile opts cabalFile = do
 
     when (null compilers) $ do
         putStrLnErr (unlines $
-                     [ "empty or missing top-level 'tested-with:' definition in .cabal file; example definition:"
+                     [ "empty or missing top-level 'tested-with:' definition in " ++ cabalFile ++ " file; example definition:"
                      , ""
                      , "tested-with: " ++ intercalate ", " [ "GHC==" ++ display v | v <- lastStableGhcVers ]
                      ])


### PR DESCRIPTION
make-travis-yml now accept cabal.project files as input argument in addition to
cabal files, generating a test script that properly validates the individual
packages.